### PR TITLE
Use 1= and |needs_review=yes for {{mono}}

### DIFF
--- a/lint error fixer.py
+++ b/lint error fixer.py
@@ -22,8 +22,8 @@ def main(queries):
                 if not((hcname in test) or ("{{" in test) or ("}}" in test) or (test == "")):
                     #print(searchlen, stext, name, end = " ")
                     if name == "tt" and not "|" in test:
-                        stext = stext.replace(hname, "{{mono|", 1)
-                        stext = stext.replace(hname, "}}", 1)
+                        stext = stext.replace(hname, "{{mono|1=", 1)
+                        stext = stext.replace(hname, "|needs_review=yes}}", 1)
                         shift+=1
                     elif name == "strike":
                         stext = stext.replace(hname, "<s>", 1)


### PR DESCRIPTION
If the content contains a = character, the parameter must be numbered or the template will break.

|needs_review=yes is used (e.g. by bots or AWB scripts) to indicate replacement of now-obsolete <tt>...</tt> markup with {{mono|...}} markup.